### PR TITLE
iOS fixes

### DIFF
--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) CGAffineTransform preferredTransform;
 @property(nonatomic, readonly) bool disposed;
 @property(nonatomic, readonly) bool isPlaying;
+@property(nonatomic, readonly) bool isSeeking;
 @property(nonatomic) bool isLooping;
 @property(nonatomic, readonly) bool isInitialized;
 @property(nonatomic, readonly) NSString* key;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -364,7 +364,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         if (_player.rate == 0 && //if player rate dropped to 0
             CMTIME_COMPARE_INLINE(_player.currentItem.currentTime, >, kCMTimeZero) && //if video was started
             CMTIME_COMPARE_INLINE(_player.currentItem.currentTime, <, _player.currentItem.duration) && //but not yet finished
-            _isPlaying) { //instance variable to handle overall state (changed to YES when user triggers playback)
+            _isPlaying &&
+            !_isSeeking) { //instance variable to handle overall state (changed to YES when user triggers playback)
             [self handleStalled];
         }
     }
@@ -503,6 +504,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void)play {
+    if (_isPlaying) {
+        return;
+    }
     _stalledCount = 0;
     _isStalledCheckStarted = false;
     _isPlaying = true;

--- a/ios/Classes/HLSCachingReverseProxyServer.swift
+++ b/ios/Classes/HLSCachingReverseProxyServer.swift
@@ -1,0 +1,218 @@
+// Based on https://github.com/StyleShare/HLSCachingReverseProxyServer
+import GCDWebServer
+import PINCache
+
+open class HLSCachingReverseProxyServer {
+    static let originURLKey = "__hls_origin_url"
+    
+    private let webServer: GCDWebServer
+    private let urlSession: URLSession
+    private let cache: PINCaching
+    
+    private(set) var port: Int?
+    
+    public init(webServer: GCDWebServer, urlSession: URLSession, cache: PINCaching) {
+        self.webServer = webServer
+        self.urlSession = urlSession
+        self.cache = cache
+        
+        self.addRequestHandlers()
+    }
+    
+    
+    // MARK: Starting and Stopping Server
+    
+    open func start(port: UInt) {
+        guard !self.webServer.isRunning else { return }
+        self.port = Int(port)
+        self.webServer.start(withPort: port, bonjourName: nil)
+    }
+    
+    open func stop() {
+        guard self.webServer.isRunning else { return }
+        self.port = nil
+        self.webServer.stop()
+    }
+    
+    
+    // MARK: Resource URL
+    
+    open func reverseProxyURL(from originURL: URL) -> URL? {
+        guard let port = self.port else { return nil }
+        
+        guard var components = URLComponents(url: originURL, resolvingAgainstBaseURL: false) else { return nil }
+        components.scheme = "http"
+        components.host = "127.0.0.1"
+        components.port = port
+        
+        let originURLQueryItem = URLQueryItem(name: Self.originURLKey, value: originURL.absoluteString)
+        components.queryItems = (components.queryItems ?? []) + [originURLQueryItem]
+        
+        return components.url
+    }
+    
+    
+    // MARK: Request Handler
+    
+    private func addRequestHandlers() {
+        self.addPlaylistHandler()
+        self.addSegmentHandler()
+        
+        
+    }
+    
+    private var lastHost: String?
+    
+    private func addPlaylistHandler() {
+        self.webServer.addHandler(forMethod: "GET", pathRegex: "/manifest|^/.*\\.m3u8$", request: GCDWebServerRequest.self) { [weak self] request, completion in
+            guard let self = self else {
+                return completion(GCDWebServerDataResponse(statusCode: 500))
+            }
+            
+            guard let originURL = self.originURL(from: request) else {
+                return completion(GCDWebServerDataResponse(statusCode: 400))
+            }
+            
+            let task = self.urlSession.dataTask(with: originURL) { data, response, error in
+                guard let data = data, let response = response else {
+                    return completion(GCDWebServerErrorResponse(statusCode: 500))
+                }
+                
+                let playlistData = self.reverseProxyPlaylist(with: data, forOriginURL: originURL)
+                let contentType = response.mimeType ?? "application/x-mpegurl"
+                completion(GCDWebServerDataResponse(data: playlistData, contentType: contentType))
+            }
+            
+            task.resume()
+        }
+    }
+    
+    private func addSegmentHandler() {
+        self.webServer.addHandler(forMethod: "GET", pathRegex: "/fragments|^/.*\\.ts$", request: GCDWebServerRequest.self) { [weak self] request, completion in
+            guard let self = self else {
+                return completion(GCDWebServerDataResponse(statusCode: 500))
+            }
+            
+            guard let originURL = self.originURL(from: request) else {
+                return completion(GCDWebServerErrorResponse(statusCode: 400))
+            }
+            
+            if let cachedData = self.cachedData(for: originURL) {
+                return completion(GCDWebServerDataResponse(data: cachedData, contentType: "video/mp2t"))
+            }
+            
+            let task = self.urlSession.dataTask(with: originURL) { data, response, error in
+                guard let data = data, let response = response else {
+                    return completion(GCDWebServerErrorResponse(statusCode: 500))
+                }
+                
+                let contentType = response.mimeType ?? "video/mp2t"
+                completion(GCDWebServerDataResponse(data: data, contentType: contentType))
+                
+                self.saveCacheData(data, for: originURL)
+            }
+            
+            task.resume()
+        }
+    }
+    
+    private func originURL(from request: GCDWebServerRequest) -> URL? {
+        guard let encodedURLString = request.query?[Self.originURLKey] else {
+            if let lastHost = lastHost {
+                var components = URLComponents(string: request.url.absoluteString)
+                components?.host = lastHost
+                components?.scheme = "https"
+                components?.port = nil
+                return components?.url
+            } else {
+                return nil
+            }
+        }
+        guard let urlString = encodedURLString.removingPercentEncoding else { return nil }
+        
+        let components = URLComponents(string: urlString)
+        lastHost = components?.host
+        let url = URL(string: urlString)
+        return url
+    }
+    
+    
+    // MARK: Manipulating Playlist
+    
+    private func reverseProxyPlaylist(with data: Data, forOriginURL originURL: URL) -> Data {
+        return String(data: data, encoding: .utf8)!
+            .components(separatedBy: .newlines)
+            .map { line in self.processPlaylistLine(line, forOriginURL: originURL) }
+            .joined(separator: "\n")
+            .data(using: .utf8)!
+    }
+    
+    private func processPlaylistLine(_ line: String, forOriginURL originURL: URL) -> String {
+        guard !line.isEmpty else { return line }
+        
+        if line.hasPrefix("#") {
+            return self.lineByReplacingURI(line: line, forOriginURL: originURL)
+        }
+        
+        if let originalSegmentURL = self.absoluteURL(from: line, forOriginURL: originURL),
+           let reverseProxyURL = self.reverseProxyURL(from: originalSegmentURL) {
+            return reverseProxyURL.absoluteString
+        }
+        
+        return line
+    }
+    
+    private func lineByReplacingURI(line: String, forOriginURL originURL: URL) -> String {
+        let uriPattern = try! NSRegularExpression(pattern: "URI=\"(.*)\"")
+        let lineRange = NSMakeRange(0, line.count)
+        guard let result = uriPattern.firstMatch(in: line, options: [], range: lineRange) else { return line }
+        
+        let uri = (line as NSString).substring(with: result.range(at: 1))
+        
+        guard let absoluteURL = self.absoluteURL(from: uri, forOriginURL: originURL) else { return line }
+        guard let reverseProxyURL = self.reverseProxyURL(from: absoluteURL) else { return line }
+        
+        return uriPattern.stringByReplacingMatches(in: line, options: [], range: lineRange, withTemplate: "URI=\"\(reverseProxyURL.absoluteString)\"")
+    }
+    
+    private func absoluteURL(from line: String, forOriginURL originURL: URL) -> URL? {
+        guard ["m3u8", "ts"].contains(originURL.pathExtension)
+                || line.range(of: "manifest", options: .caseInsensitive) != nil
+                || line.range(of: "fragments", options: .caseInsensitive) != nil else {
+            return nil
+        }
+        
+        if line.hasPrefix("http://") || line.hasPrefix("https://") {
+            return URL(string: line)
+        }
+        
+        guard let scheme = originURL.scheme, let host = originURL.host else { return nil }
+        
+        let path: String
+        if line.hasPrefix("/") {
+            path = line
+        } else {
+            path = originURL.deletingLastPathComponent().appendingPathComponent(line).path
+        }
+        
+        let url = URL(string: scheme + "://" + host + path)?.standardized
+        return url
+    }
+    
+    
+    // MARK: Caching
+    
+    private func cachedData(for resourceURL: URL) -> Data? {
+        let key = self.cacheKey(for: resourceURL)
+        return self.cache.object(forKey: key) as? Data
+    }
+    
+    private func saveCacheData(_ data: Data, for resourceURL: URL) {
+        let key = self.cacheKey(for: resourceURL)
+        self.cache.setObject(data, forKey: key)
+    }
+    
+    private func cacheKey(for resourceURL: URL) -> String {
+        return resourceURL.relativePath.data(using: .utf8)!.base64EncodedString()
+    }
+}

--- a/ios/better_player.podspec
+++ b/ios/better_player.podspec
@@ -17,7 +17,6 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'Cache', '~> 6.0.0'
   s.dependency 'GCDWebServer'
-  s.dependency 'HLSCachingReverseProxyServer'
   s.dependency 'PINCache'
   
   s.platform = :ios, '11.0'


### PR DESCRIPTION
- Fix HLS caching. Had to move the **HLSCachingReverseProxyServer** dependency into the project, because can't specify a custom repo in _.podspec_
- Fix seeking. Introduced the **isSeeking** property and setup an exception for stalling.
- Fix DRM delegate in **CacheManager**. The **AVAssetResourceLoader** holds a weak reference to the delegate, so it needs to be stored globally.